### PR TITLE
fix: #28 以前のパスワードが上書きされる不具合の修正

### DIFF
--- a/save_password_function.sh
+++ b/save_password_function.sh
@@ -5,6 +5,10 @@ save_password() {
   read -p "ユーザー名を入力してください：" user_name
   read -s -p "パスワードを入力してください：" password
 
+  # 復号化
+  # 標準エラー出力を/dev/nullに捨てる
+  gpg --yes storage.txt.asc > storage.txt 2> /dev/null
+
   # 次の行がターミナル上で前の行にインライン表示されることを防ぐために改行する
   echo
   echo "${service_name}:${user_name}:${password}" >> storage.txt


### PR DESCRIPTION
# 概要
以前のパスワードが上書きされる不具合を修正しました。
# 詳細
パスワード保存関数（`save_password_function.sh`）において、ユーザーの入力情報を`storage.txt`に保存する前に、`storage.txt.asc`を復号化する処理を追加しました。
これにより、正常にパスワードが保存されるようになりました。

closes #28 